### PR TITLE
Extend .env file capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ CRYPT_KEY
 
 all configs for each environment may be stored at {ENV_NAME}.json files
 
+## define instance specific connfig file
+.env
+
+```
+ENV_NAME;INSTANCE_NAME
+CRYPT_KEY
+```
+all configs for each instance may be stored at {ENV_NAME}-{INSTANCE_NAME}.json files
+
+Note: {ENV_NAME}.json config value has more priority that {ENV_NAME}-{INSTANCE_NAME}.json
+
 ## crypt your configs values
 
 config/test.json

--- a/rdconfig.js
+++ b/rdconfig.js
@@ -15,7 +15,13 @@ var RDConfig = function(forceEnvName){
         if(typeof forceEnvName === "string"){
             envFileContent[0] = forceEnvName
         }
-        process.env['NODE_ENV'] = envFileContent[0];
+        
+        var props = envFileContent[0].split(';');
+        process.env['NODE_ENV'] = props[0];
+        if(typeof props[1] === "string") {
+            process.env['NODE_APP_INSTANCE'] = props[1];
+        }
+        
         if(envFileContent.length > 1) {
             cryptKey = envFileContent[1];
         }


### PR DESCRIPTION
The original node-config library supports Instance specific configuration files, using `NODE_APP_INSTANCE` env variable.

In this pull request, I extend .env file capabilities.
Now you can set both, env level and instance level configuration `production;eu` 