### PR TITLE
fix missing config types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "rdconfig",
   "version": "1.4.0",
-
   "description": "rdconfig - unified configuration for node apps, based on lorenwest/node-config",
-
   "main": "rdconfig.js",
   "types": "rdconfig.d.ts",
   "bin": {
@@ -15,7 +13,9 @@
     "ejs": "^2.3.3",
     "rdcrypto": "0.*"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@types/config": "0.0.31"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
@AndrianBdn @melya 

I've forgot add typings for config library to the package dependencies, so on compiling I've got this error:

/node_modules/rdconfig/rdconfig.d.ts(9,25): error TS2304: Cannot find name 'config'.

This line in package.json will fix this issue